### PR TITLE
Add support for live preview and live navigation

### DIFF
--- a/src/Margin/Browser.cs
+++ b/src/Margin/Browser.cs
@@ -26,15 +26,13 @@ namespace MarkdownEditor
         private MarkdownDocument _markdownDoc;
         private List<Block> _markdownBlocks;
 
-        private MarkdownPipelineBuilder _pipelineBuilder;
-
         public Browser(string file)
         {
             var builder = new MarkdownPipelineBuilder()
                 .UsePragmaLines()
                 .UseAdvancedExtensions();
 
-            _pipeline = _pipelineBuilder.Build();
+            _pipeline = builder.Build();
             _zoomFactor = GetZoomFactor();
             _file = file;
             _htmlTemplate = GetHtmlTemplate();
@@ -150,6 +148,8 @@ namespace MarkdownEditor
             {
                 var closestLine = FindClosestLine(line);
 
+                //Trace.WriteLine($"Closest line: {line} -> {closestLine}");
+
                 var element = _htmlDocument.getElementById("pragma-line-" + closestLine);
                 if (element != null)
                 {
@@ -164,22 +164,17 @@ namespace MarkdownEditor
 
             var htmlWriter = new StringWriter();
             var htmlRenderer = new HtmlRenderer(htmlWriter);
-
-            // TODO: This is a workaround as we don't have access to the extensions
-            foreach (var extension in _pipelineBuilder.Extensions)
-            {
-                extension.Setup(htmlRenderer);
-            }
+            _pipeline.Setup(htmlRenderer);
             htmlRenderer.Render(doc);
             htmlWriter.Flush();
             var html = htmlWriter.ToString();
 
-            _markdownDoc = doc;
-
             // TODO: use a pool for List<Block>
             var blocks = new List<Block>();
-            DumpBlocks(_markdownDoc, blocks);
+            DumpBlocks(doc, blocks);
+
             _markdownBlocks = blocks;
+            _markdownDoc = doc;
 
             if (_htmlDocument != null)
             {

--- a/src/Margin/Browser.cs
+++ b/src/Margin/Browser.cs
@@ -201,7 +201,7 @@ namespace MarkdownEditor
             {
                 foreach (var subBlock in container)
                 {
-                    blocks.Add(subBlock);
+                    DumpBlocks(subBlock, blocks);
                 }
             }
         }

--- a/src/Margin/Browser.cs
+++ b/src/Margin/Browser.cs
@@ -203,10 +203,9 @@ namespace MarkdownEditor
                 // TODO: use a pool for List<Block>
                 // Collect all blocks for sync navigation
                 var blocks = new List<Block>();
-                if (MarkdownEditorPackage.Options.EnablePreviewSyncNavigation)
-                {
-                    DumpBlocks(doc, blocks);
-                }
+                // This is used by live sync navigation, but we always generate them so that 
+                // we can enable/disable the sync navigation and it will work correctly
+                DumpBlocks(doc, blocks); 
                 _markdownBlocks = blocks;
             }
             catch (Exception ex)

--- a/src/Margin/BrowserMargin.cs
+++ b/src/Margin/BrowserMargin.cs
@@ -75,9 +75,6 @@ namespace MarkdownEditor
             await Dispatcher.BeginInvoke(new Action(() =>
             {
                 var lineNumber = _textView.TextSnapshot.GetLineNumberFromPosition(_textView.TextViewLines.FirstVisibleLine.Start.Position);
-
-                Trace.WriteLine($"Linenumber: {lineNumber}");
-
                 _browser.UpdatePosition(lineNumber);
 
             }), DispatcherPriority.ApplicationIdle, null);

--- a/src/Margin/BrowserMargin.cs
+++ b/src/Margin/BrowserMargin.cs
@@ -142,8 +142,9 @@ namespace MarkdownEditor
             if (_textView != null)
                 _textView.LayoutChanged -= LayoutChanged;
 
-            if (_document != null)
-                _document.TextBuffer.Changed -= TextBufferChanged;
+            var textBuffer = _document?.TextBuffer;
+            if (textBuffer != null)
+                textBuffer.Changed -= TextBufferChanged;
         }
     }
 }

--- a/src/Margin/BrowserMargin.cs
+++ b/src/Margin/BrowserMargin.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Threading;
@@ -11,11 +12,30 @@ namespace MarkdownEditor
     {
         private readonly Browser _browser;
         private readonly ITextDocument _document;
+        private readonly DispatcherTimer _updaterDocument;
+        private readonly DispatcherTimer _updaterPosition;
+        private readonly ITextView _textView;
 
-        public BrowserMargin(ITextDocument document)
+        /// <summary>
+        /// The number of seconds to wait before updating the position/document
+        /// TODO: We may want this to be configurable in the settings
+        /// </summary>
+        private const double RefreshAfterSeconds = 0.5;
+
+        public BrowserMargin(ITextView textview, ITextDocument document)
         {
+            _textView = textview;
+
+            _updaterDocument = new DispatcherTimer {Interval = TimeSpan.FromSeconds(RefreshAfterSeconds) };
+            _updaterDocument.Tick += UpdaterDocumentOnTick;
+
+            _updaterPosition = new DispatcherTimer { Interval = TimeSpan.FromSeconds(RefreshAfterSeconds) };
+            _updaterPosition.Tick += UpdaterPositionOnTick;
+
+            _textView.LayoutChanged += LayoutChanged;
+
             _document = document;
-            _document.FileActionOccurred += DocumentUpdated;
+            _document.TextBuffer.Changed += TextBufferChanged;
 
             _browser = new Browser(_document.FilePath);
             CreateMarginControls();
@@ -26,12 +46,41 @@ namespace MarkdownEditor
         public double MarginSize => MarkdownEditorPackage.Options.PreviewWindowWidth;
         public FrameworkElement VisualElement => this;
 
-        private void DocumentUpdated(object sender, TextDocumentFileActionEventArgs e)
+        private void LayoutChanged(object sender, TextViewLayoutChangedEventArgs textViewLayoutChangedEventArgs)
         {
-            if (e.FileActionType == FileActionTypes.ContentSavedToDisk)
+            _updaterPosition.Stop();
+            _updaterPosition.Start();
+        }
+
+        private void UpdaterDocumentOnTick(object sender, EventArgs eventArgs)
+        {
+            _updaterDocument.Stop();
+            UpdateBrowser();
+        }
+
+        private void UpdaterPositionOnTick(object sender, EventArgs eventArgs)
+        {
+            _updaterPosition.Stop();
+            UpdatePosition();
+        }
+
+        private void TextBufferChanged(object sender, TextContentChangedEventArgs e)
+        {
+            _updaterDocument.Stop();
+            _updaterDocument.Start();
+        }
+
+        private async void UpdatePosition()
+        {
+            await Dispatcher.BeginInvoke(new Action(() =>
             {
-                UpdateBrowser();
-            }
+                var lineNumber = _textView.TextSnapshot.GetLineNumberFromPosition(_textView.TextViewLines.FirstVisibleLine.Start.Position);
+
+                Trace.WriteLine($"Linenumber: {lineNumber}");
+
+                _browser.UpdatePosition(lineNumber);
+
+            }), DispatcherPriority.ApplicationIdle, null);
         }
 
         private async void UpdateBrowser()
@@ -90,8 +139,11 @@ namespace MarkdownEditor
             if (_browser != null)
                 _browser.Dispose();
 
+            if (_textView != null)
+                _textView.LayoutChanged -= LayoutChanged;
+
             if (_document != null)
-                _document.FileActionOccurred -= DocumentUpdated;
+                _document.TextBuffer.Changed -= TextBufferChanged;
         }
     }
 }

--- a/src/Margin/BrowserMarginProvider.cs
+++ b/src/Margin/BrowserMarginProvider.cs
@@ -26,7 +26,7 @@ namespace MarkdownEditor
             if (!TextDocumentFactoryService.TryGetTextDocument(wpfTextViewHost.TextView.TextDataModel.DocumentBuffer, out document))
                 return null;
 
-            return new BrowserMargin(document);
+            return new BrowserMargin(wpfTextViewHost.TextView, document);
         }
     }
 }

--- a/src/Options/Options.cs
+++ b/src/Options/Options.cs
@@ -30,6 +30,12 @@ namespace MarkdownEditor
         public bool EnablePreviewWindow { get; set; } = true;
 
         [Category("Preview Window")]
+        [DisplayName("Sync Navigation")]
+        [Description("Determines if the preview should synchronize while navigating into the document")]
+        [DefaultValue(true)]
+        public bool EnablePreviewSyncNavigation { get; set; } = true;
+
+        [Category("Preview Window")]
         [DisplayName("Width")]
         [Description("The width of the preview window in pixels. Default is 600")]
         [DefaultValue(600)]


### PR DESCRIPTION
Hi @madskristensen,

I have started to work on:
- a live preview that would update the document at every typing (after a 0.5s delay of pause)
- a live navigation that scrolls according to the top level line

This PR is not yet ready for merge, it's a work in progress! Just wanted to get early feedback on it.

The live preview seems working well.
For the live navigation, I have yet to found a more reliable way to scroll to the best suitable position. It may also be more relevant to keep the previous system (offset in document) and provide a settings+a button to disable live navigation sync.