### PR TITLE
Add better support for smart continuation

### DIFF
--- a/src/Commands/IndentationCommandTarget.cs
+++ b/src/Commands/IndentationCommandTarget.cs
@@ -21,7 +21,7 @@ namespace MarkdownEditor
 
             var text = _view.Caret.ContainingTextViewLine.Extent.GetText();
 
-            if (!SmartIndentCommandTarget._regex.IsMatch(text))
+            if (!SmartIndentCommandTarget.Match(text))
                 return false;
 
             var position = extend.Start.Position;

--- a/src/Commands/SmartIndentCommandTarget.cs
+++ b/src/Commands/SmartIndentCommandTarget.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+using System.Text;
 using System.Text.RegularExpressions;
+using Markdig;
+using Markdig.Extensions.Footers;
+using Markdig.Syntax;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
@@ -8,69 +12,179 @@ namespace MarkdownEditor
 {
     internal class SmartIndentCommandTarget : CommandTargetBase<VSConstants.VSStd2KCmdID>
     {
-        public static Regex _regex = new Regex(@"^(([\s]+)?(?<bullet>-|\*|>|\+|([0-9a-z]).)\s(\[ \]|\[x\])?\s?)", RegexOptions.IgnoreCase);
+        private static readonly MarkdownPipeline DefaultPipeline;
+
+        static SmartIndentCommandTarget()
+        {
+            // Use a bare bone pipeline
+            DefaultPipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
+        }
 
         public SmartIndentCommandTarget(IVsTextView adapter, IWpfTextView textView)
             : base(adapter, textView, VSConstants.VSStd2KCmdID.RETURN)
-        { }
+        {
+        }
+
+        public static bool Match(string text)
+        {
+            MarkdownDocument doc;
+            return Match(text, out doc);
+        }
+
+        public static bool Match(string text, out MarkdownDocument doc)
+        {
+            doc = Markdown.Parse(text, DefaultPipeline);
+            return doc.Count != 0 && (doc[0] is QuoteBlock || doc[0] is ListBlock | doc[0] is CodeBlock || doc[0] is FooterBlock);
+        }
 
         protected override bool Execute(VSConstants.VSStd2KCmdID commandId, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
         {
             var extend = _view.Caret.ContainingTextViewLine.Extent;
             var text = extend.GetText();
-            var match = _regex.Match(text);
 
-            if (!match.Success)
-                return false;
+            MarkdownDocument doc;
 
-            var newline = Environment.NewLine;
-
-            if (string.IsNullOrWhiteSpace(_regex.Replace(text, "")))
+            if (!Match(text, out doc))
             {
+                return false;
+            }
+
+            // Get the last container and last child
+            ContainerBlock lastContainer = doc;
+            Block firstChild = doc[0];
+            var lastChild = firstChild;
+            while (lastChild != null)
+            {
+                var container = lastChild as ContainerBlock;
+                if (container != null)
+                {
+                    lastContainer = container;
+                    lastChild = container.LastChild;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            if (lastChild == null)
+            {
+                // We rebuild the new line up to the last parent container
+                var newLine = lastContainer == firstChild
+                                  ? string.Empty
+                                  : BuildNewLine(firstChild, lastContainer.Parent);
+
                 using (var edit = _view.TextBuffer.CreateEdit())
                 {
                     edit.Delete(extend);
-                    edit.Insert(extend.Start, newline);
+                    edit.Insert(extend.Start, string.IsNullOrEmpty(newLine) ? Environment.NewLine : newLine);
                     edit.Apply();
                 }
-
-                return true;
             }
+            else
+            {
+                var newLine = BuildNewLine(firstChild, lastChild);
+                var position = _view.Caret.Position.BufferPosition;
 
-            var position = _view.Caret.Position.BufferPosition;
+                // Make 2 separate edits so the auto-insertion of list items can be undone (ctrl-z)
+                _view.TextBuffer.Insert(position, Environment.NewLine);
+                _view.TextBuffer.Insert(position + Environment.NewLine.Length, newLine);
 
-            string insertionText = ParseInput(match);
-
-            // Make 2 separate edits so the auto-insertion of list items can be undone (ctrl-z)
-            _view.TextBuffer.Insert(position, newline);
-            _view.TextBuffer.Insert(position + newline.Length, insertionText);
-
+            }
             return true;
         }
 
-        private string ParseInput(Match match)
+        private string BuildNewLine(Block firstChild, Block lastChild)
         {
-            string text = match.Value;
-            var bullet = match.Groups["bullet"].Value;
+            var builder = new StringBuilder();
 
-            if (bullet.EndsWith("."))
+            var child = firstChild;
+            var column = 0;
+
+            // Special when there is a list but the last container is not a list
+            // in this case, we will skip the list and keep other containers
+            // when rebuilding the new line
+            var lastContainer = lastChild as ContainerBlock ?? lastChild.Parent;
+            bool skipList = !(lastContainer is ListItemBlock);
+
+            while (child != null)
             {
-                var clean = bullet.TrimEnd('.');
-
-                int number;
-                if (int.TryParse(bullet, out number))
+                for (; column < child.Column; column++)
                 {
-                    number += 1;
-                    text = text.Replace(bullet, number + ".");
+                    builder.Append(' ');
                 }
-                else if (clean.Length == 1 && clean[0] < 'z')
+
+                if (!skipList && child is ListItemBlock)
                 {
-                    var c = clean[0] + 1;
-                    text = text.Replace(bullet, (char)c + ".");
+                    var listItem = (ListItemBlock) child;
+                    var list = (ListBlock) listItem.Parent;
+
+                    var startLength = builder.Length;
+                    if (list.IsOrdered)
+                    {
+                        var c = list.OrderedStart[0];
+                        if (c >= '0' && c <= '9')
+                        {
+                            int value;
+                            int.TryParse(list.OrderedStart, out value);
+                            value++;
+                            builder.Append(value);
+                        }
+                        else if (c >= 'a' && c <= 'z')
+                        {
+                            c = (char)(c + 1);
+                            c = c > 'z' ? 'z' : c;
+                            builder.Append(c);
+                        }
+                        else
+                        {
+                            // We don't know how to generate a new item so we replicate it (as it is valid in Markdown)
+                            builder.Append(list.OrderedStart);
+                        }
+
+                        builder.Append(list.OrderedDelimiter);
+                    }
+                    else
+                    {
+                        builder.Append(list.BulletType);
+                    }
+
+                    // A list requires at least one space after the bullet
+                    builder.Append(' ');
+
+                    // Shift column state
+                    column += builder.Length - startLength;
+                }
+                else if (child is QuoteBlock)
+                {
+                    var quoteBlock = (QuoteBlock)child;
+                    builder.Append(quoteBlock.QuoteChar);
+                    column++;
+                }
+                else if (child is FooterBlock)
+                {
+                    var footerBlock = (FooterBlock)child;
+                    builder.Append(footerBlock.OpeningCharacter);
+                    builder.Append(footerBlock.OpeningCharacter);
+                    column += 2;
+                }
+
+                if (child == lastChild)
+                {
+                    break;
+                }
+
+                var container = child as ContainerBlock;
+                if (container != null)
+                {
+                    child = container.LastChild;
+                }
+                else
+                {
+                    break;
                 }
             }
-
-            return text;
+            return builder.ToString();
         }
 
         protected override bool IsEnabled()

--- a/src/Commands/ToogleTaskCommandTarget.cs
+++ b/src/Commands/ToogleTaskCommandTarget.cs
@@ -57,7 +57,7 @@ namespace MarkdownEditor
 
             var text = _span.GetText();
 
-            return SmartIndentCommandTarget._regex.IsMatch(text);
+            return SmartIndentCommandTarget.Match(text);
         }
     }
 }


### PR DESCRIPTION
Hi, 
This PR brings improvement for the smart continuation by supporting nested blocks like this:

```
> 1. block
> 2. block2
```
but also this case where the blockquote has to continue but not the list:

```
1. > block
   > continuation
```
To fully support the previous case (or even nested lists), we would ideally have to backtrack and parse not only the current line but previous lines... but that's an improvement we can make later if it is really needed.

The new smart completion is using the Markdown parser instead of regex to make it more accurate (e.g a character after an ordered list can be either `.` or `)`). It should also better handle correctly accurate column indenting.
