### PR TITLE
Fix typo

### DIFF
--- a/src/source.extension.cs
+++ b/src/source.extension.cs
@@ -9,7 +9,7 @@ namespace MarkdownEditor
     {
         public const string Id = "9ca64947-e9ca-4543-bfb8-6cce9be19fd6";
         public const string Name = "Markdown Editor";
-        public const string Description = @"A full featured Markdown editor with live preview and syntax highligting. Supports GitHub flavored Markdown.";
+        public const string Description = @"A full featured Markdown editor with live preview and syntax highlighting. Supports GitHub flavored Markdown.";
         public const string Language = "en-US";
         public const string Version = "1.10";
         public const string Author = "Mads Kristensen";

--- a/src/source.extension.resx
+++ b/src/source.extension.resx
@@ -121,7 +121,7 @@
     <value>Markdown Editor</value>
   </data>
   <data name="112" xml:space="preserve">
-    <value>A full featured Markdown editor with live preview and syntax highligting. Supports GitHub flavored Markdown.</value>
+    <value>A full featured Markdown editor with live preview and syntax highlighting. Supports GitHub flavored Markdown.</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="400" type="System.Resources.ResXFileRef, System.Windows.Forms">

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
   <Metadata>
 	<Identity Id="9ca64947-e9ca-4543-bfb8-6cce9be19fd6" Version="1.10" Language="en-US" Publisher="Mads Kristensen" />
 	<DisplayName>Markdown Editor</DisplayName>
-	<Description xml:space="preserve">A full featured Markdown editor with live preview and syntax highligting. Supports GitHub flavored Markdown.</Description>
+	<Description xml:space="preserve">A full featured Markdown editor with live preview and syntax highlighting. Supports GitHub flavored Markdown.</Description>
 	<MoreInfo>https://github.com/madskristensen/MarkdownEditor</MoreInfo>
 	<License>Resources\LICENSE</License>
 	<ReleaseNotes>https://github.com/madskristensen/MarkdownEditor/blob/master/CHANGELOG.md</ReleaseNotes>


### PR DESCRIPTION
### Installed product versions
- Visual Studio: 2015 Enterprise
- This extension: 1.10.180

### Description
The Visual Studio Gallery has a typo in the description: 

    A full featured Markdown editor with live preview and syntax highligting.
                                                                       ^^

### Steps to recreate
1. Tools
2. Extensions and Updates
3. Online
4. Visual Studio Gallery
5. Search for `markdown` (congrats on number one result btw)
6. Read description

### Current behavior
Description has `highligting` in it.

### Expected behavior
Description has `highlighting` in it.