### PR TITLE
Fixes browser width problem when moving splitter

### DIFF
--- a/src/Margin/BrowserMargin.cs
+++ b/src/Margin/BrowserMargin.cs
@@ -77,7 +77,7 @@ namespace MarkdownEditor
             Grid grid = new Grid();
             grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(0, GridUnitType.Star) });
             grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(5, GridUnitType.Pixel) });
-            grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(width, GridUnitType.Pixel) });
+            grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(width, GridUnitType.Pixel), MinWidth = 150 });
             grid.RowDefinitions.Add(new RowDefinition());
 
             grid.Children.Add(Browser.Control);
@@ -92,6 +92,10 @@ namespace MarkdownEditor
             splitter.VerticalAlignment = VerticalAlignment.Stretch;
             splitter.HorizontalAlignment = HorizontalAlignment.Stretch;
             splitter.DragCompleted += RightDragCompleted;
+            splitter.DragDelta += (e, s) => 
+            {
+                grid.ColumnDefinitions[2].MaxWidth = (_textView.ViewportWidth + grid.ColumnDefinitions[2].Width.Value) * 0.8;
+            };
 
             grid.Children.Add(splitter);
             Grid.SetColumn(splitter, 1);


### PR DESCRIPTION
With no maximum width set for the browser column, you could drag the
window splitter until the browser would size beyond the width of VS and
cover other windows.  The MaxWidth of the column is now set to 80% of
the total editor+browswer width.  I've also set the minimum width to be
150 pixels which keeps some odd behavior from happening when set to less
than that.