### PR TITLE
Enable navigation bar toggle

### DIFF
--- a/src/LanguageService/MarkdownLanguage.cs
+++ b/src/LanguageService/MarkdownLanguage.cs
@@ -22,7 +22,14 @@ namespace MarkdownEditor
 
         public override TypeAndMemberDropdownBars CreateDropDownHelper(IVsTextView forView)
         {
-            return new DropDownTocBars(this, forView);
+            if (preferences.ShowNavigationBar)
+            {
+                return new DropDownTocBars(this, forView);
+            }
+            else
+            {
+                return base.CreateDropDownHelper(forView);
+            }
         }
 
         public override LanguagePreferences GetLanguagePreferences()
@@ -45,11 +52,9 @@ namespace MarkdownEditor
                     preferences.MaxErrorMessages = 100;
                     preferences.AutoOutlining = false;
                     preferences.MaxRegionTime = 2000;
-                    preferences.ShowNavigationBar = true;
                     preferences.InsertTabs = false;
                     preferences.IndentSize = 2;
                     preferences.IndentStyle = IndentingStyle.Smart;
-                    preferences.ShowNavigationBar = true;
 
                     preferences.WordWrap = true;
                     preferences.WordWrapGlyphs = true;


### PR DESCRIPTION
### Installed product versions
- Visual Studio Community 2017 version 15.4.4
- This extension versions 1.11.214 and 1.11.225

### Description

With this extension installed, the navigation bar dropdowns are always displayed for markdown files, regardless of the selected *Navigation bar* setting under *Tools > Options > Text Editor > Markdown*:

![toggle-options](https://user-images.githubusercontent.com/1977895/33055596-6dd6a362-ce35-11e7-83b7-414d885e95ed.png)

When the *Navigation bar* setting is unchecked, I would expect for the navigation bar dropdowns to not be displayed. This pull request is my proposed fix to enable the user to toggle the navigation bar on and off.

### Steps to recreate

1. Install the extension.
2. Open Visual Studio.
3. Go to *Tools > Options > Text Editor > Markdown* and uncheck the *Navigation bar* setting.
4. Open a markdown document.
5. Observe whether or not the navigation bar dropdowns are displayed. <sup>[2]</sup>

### Current behavior

The navigation dropdowns are displayed when then the *Navigation bar* setting is unchecked.

![toggle-on](https://user-images.githubusercontent.com/1977895/33056883-d60a02b0-ce3c-11e7-9749-9a61f0be355b.png)

### Expected behavior

The navigation dropdowns should **not** be displayed when then the *Navigation bar* setting is unchecked.

![toggle-off](https://user-images.githubusercontent.com/1977895/33057019-81068878-ce3d-11e7-85ae-b2d16a8527bb.png)

### Notes

1. For reference, the relevant Microsoft technical documentation for this topic is titled [*Support for the Navigation Bar in a Legacy Language Service*](https://docs.microsoft.com/en-us/visualstudio/extensibility/internals/support-for-the-navigation-bar-in-a-legacy-language-service).

2. Whenever the *Navigation bar* setting is changed, the user must close and reopen the editor window before the change takes place. See the last paragraph in the section titled [*Enabling Support for the Navigation Bar*](https://docs.microsoft.com/en-us/visualstudio/extensibility/internals/support-for-the-navigation-bar-in-a-legacy-language-service#enabling-support-for-the-navigation-bar) in the Microsoft technical documentation for this topic.

3. The *Navigation bar* setting selected by the user should be persisted across sessions; this happens automatically. It should not get overwritten when the user opens a new instance of Visual Studio.
