### PR TITLE
Add Markdown Editor Option grid to Visual Studio

### DIFF
--- a/src/MarkdownEditorPackage.cs
+++ b/src/MarkdownEditorPackage.cs
@@ -14,6 +14,7 @@ namespace MarkdownEditor
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
     [InstalledProductRegistration("#110", "#112", Vsix.Version, IconResourceID = 400)]
     [ProvideMenuResource("Menus.ctmenu", 1)]
+    [ProvideOptionPage(typeof(Options),  "Markdown Editor", "Markdown Editor Options", 0, 0, true)]  
 
     [ProvideLanguageService(typeof(MarkdownLanguage), MarkdownLanguage.LanguageName, 100, ShowDropDownOptions = true, DefaultToInsertSpaces = true, EnableCommenting = true, AutoOutlining = true, MatchBraces = true, MatchBracesAtCaret = true, ShowMatchingBrace = true, ShowSmartIndent = true)]
     [ProvideLanguageEditorOptionPage(typeof(Options), MarkdownLanguage.LanguageName, null, "Advanced", "#101", new[] { "markdown", "md" })]


### PR DESCRIPTION
This change adds the ability to view and modify options for Markdown Editor in Visual Studio 2017 via the Tool > Options menu.