### PR TITLE
Add an option to set the HTML file extension

### DIFF
--- a/src/Options/Options.cs
+++ b/src/Options/Options.cs
@@ -11,6 +11,12 @@ namespace MarkdownEditor
         [Description("When a .html file exist in the same folder as an .md file it should automatically sync the .html file on save.")]
         [DefaultValue(true)]
         public bool GenerateHtmlFiles { get; set; } = true;
+        
+        [Category("HTML Generation")]
+        [DisplayName("HTML file extension")]
+        [Description("The file extension to use for the HTML file synced with the .md file in the HTML Generation process. Default is .html. Use .cshtml to generate html that can be incorporated with the Razor templating engine.")]
+        [DefaultValue(".html")]
+        public string HtmlFileExtension { get; set; } = ".html";
 
         [Category("HTML Generation")]
         [DisplayName("HTML Template file name")]


### PR DESCRIPTION
This option allows users to modify the file extension used in the generation of HTML files. The default remains .html, but this option allows the output to have a .cshtml extension. This allows documentation to be written in Markdown and a .cshtml file to be generated (combined with the HTML Template) to automatically produce web help pages for an MVC web application using the Razor template engine. It means there is no double handling or special code needed to integrate documentation into the web application - just write the Markdown and the a HTML Help file is generated and can be called by the appropriate Controller. 

The Razor engine takes care of the styling, layout etc. of the Help text.