### PR TITLE
Enable html output using file extension read from Markdown Editor Opt…

### DIFF
--- a/src/Commands/GenerateHtmlTarget.cs
+++ b/src/Commands/GenerateHtmlTarget.cs
@@ -18,10 +18,13 @@ namespace MarkdownEditor
     {
         private readonly Package _package;
         private ProjectItem _item;
+        private string htmlExtension = ".html";
 
         private GenerateHtml(Package package)
         {
             _package = package;
+            
+            htmlExtension = MarkdownEditorPackage.Options.HTMLFileExtension;
 
             var commandService = (OleMenuCommandService)ServiceProvider.GetService(typeof(IMenuCommandService));
             if (commandService != null)
@@ -65,7 +68,7 @@ namespace MarkdownEditor
             if (!ContentTypeDefinition.MarkdownExtensions.Contains(ext, StringComparer.OrdinalIgnoreCase))
                 return;
 
-            var htmlFile = GetHtmlFileName(markdownFile);
+            var htmlFile = GetHtmlFileName(markdownFile, htmlExtension);
 
             button.Checked = File.Exists(htmlFile);
             button.Visible = button.Enabled = true;
@@ -74,7 +77,7 @@ namespace MarkdownEditor
         private void Execute(object sender, EventArgs e)
         {
             string markdownFile = _item.FileNames[1];
-            string htmlFile = GetHtmlFileName(markdownFile);
+            string htmlFile = GetHtmlFileName(markdownFile, htmlExtension);
 
             if (File.Exists(htmlFile))
             {
@@ -96,7 +99,7 @@ namespace MarkdownEditor
             var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
             var html = Markdown.ToHtml(content, pipeline).Replace("\n", Environment.NewLine);
 
-            string htmlFileName = GetHtmlFileName(markdownFile);
+            string htmlFileName = GetHtmlFileName(markdownFile, htmlExtension);
             html = CreateFromHtmlTemplate(markdownFile, content, html);
 
             File.WriteAllText(htmlFileName, html, new UTF8Encoding(true));
@@ -172,7 +175,7 @@ namespace MarkdownEditor
 
         public static bool HtmlGenerationEnabled(string markdownFile)
         {
-            string htmlFile = GetHtmlFileName(markdownFile);
+            string htmlFile = GetHtmlFileName(markdownFile, htmlExtension);
 
             return File.Exists(htmlFile);
         }
@@ -180,6 +183,11 @@ namespace MarkdownEditor
         private static string GetHtmlFileName(string markdownFile)
         {
             return Path.ChangeExtension(markdownFile, ".html");
+        }
+        
+         private static string GetHtmlFileName(string markdownFile, string extension)
+        {
+            return Path.ChangeExtension(markdownFile, extension);
         }
     }
 }


### PR DESCRIPTION
…ions

These changes allow the generated HTML to use the file extension set in the Markdown Editor Options. The default is .html, but other extensions can be set via the Options page in Visual Studio, such as .cshtml for use with the Razor template engine.