### PR TITLE
Remove hard coded font for markdown code

### DIFF
--- a/src/Classifier/MarkdownClassificationTypes.cs
+++ b/src/Classifier/MarkdownClassificationTypes.cs
@@ -85,7 +85,6 @@ namespace MarkdownEditor
     {
         public MarkdownCodeFormatDefinition()
         {
-            FontTypeface = new Typeface("Courier New");
             DisplayName = "Markdown Code";
         }
     }


### PR DESCRIPTION
Fixes #179.

This hard coded font caused jumping text while typing.

The downside to this change is that inline code blocks now look the same as regular text (by default). On my PC I've configured it to have a slightly different foreground colour via Options/Fonts and Colors. However I also use a dark theme, and the default colours in this extension are not great on dark themes. Adding another colour here will make exacerbate the problem for dark theme users, so I opted not to. Is it straightforward to add defaults for both light and dark themes?

